### PR TITLE
Corrected rand and rand_element functions

### DIFF
--- a/bin/basename
+++ b/bin/basename
@@ -1,5 +1,5 @@
 #!/bin/bash
-basename () { 
+main () { 
 	if [[ -z "$2" ]]; then
 		echo ${1##*/} 	 # This pretty much does all the work: ${VAR##*/}
 	else

--- a/function/rand
+++ b/function/rand
@@ -3,9 +3,15 @@
 # (GPLv3) as published by the Free Software Foundation. 
 # <http://www.gnu.org/licenses/> <https://github.com/dalhuijsen/bashnative>
 
-# @Usage:  rand INTEGER will return a random number between 0 and INTEGER
+# @Usage:  rand INTEGER will return a random number in the range (0, INTEGER]
 # @Depends: none
+# 
+# The bash RANDOM variable returns a pseudorandom number in the range (0,32767)
+# -- 32768 distinct values.  Therefore, to ensure we get a number in the range
+# (0,INTEGER], we must ensure that integer division RANDOM / DIVISOR *never*
+# equals 1; Hence, we must use 32768 as the DIVISOR.
+# 
 rand() {
-	printf $((  $1 *  RANDOM  / 32767   ))
+    echo $(( $1 * RANDOM / 32768 ))
 }
 

--- a/function/rand_element
+++ b/function/rand_element
@@ -5,10 +5,13 @@
 
 # @Usage:  rand_element SPACE SEPARATED LIST will return one element from that list
 # @Depends: bashnative/rand
-
+# 
+# Emits a pseudorandom selection of one of its arguments to standard output.  Args are put into the
+# array $th, and are enumerated beginning at index 0 to N-1; 'rand N' returns an appropriate index
+# in the range: (0,N]
+# 
 rand_element () {
     local -a th=("$@")
-    unset th[0]
-    printf $'%s\n' "${th[$(($(rand "${#th[*]}")+1))]}"
+    echo "${th[$( rand ${#th[@]} )]}"
 }
 


### PR DESCRIPTION
The 'rand N' function is supposed to return a value in the range (0, N]  non-inclusive; it was incorrectly using 32767 as a divisor for RANDOM instead of 32768, erroneously returning the value N occasionally (once every 32K calls, on average).

The 'rand_element ...' function is supposed to return a random instance of one of its N arguments.  It would never return the first argument.

Added unit tests to z_build/tdd.sh to test the rand and rand_element.  Ensures that rand respects the range (0,N] and maintains a reasonable statistical distribution, and that rand_element returns every one of its arguments, and never returns anything else.
